### PR TITLE
Fix primary port assignment for NWA55AXE

### DIFF
--- a/package/uintent/files/lib/uintent/config.d/01-interface.sh
+++ b/package/uintent/files/lib/uintent/config.d/01-interface.sh
@@ -4,7 +4,8 @@
 . /lib/functions/system.sh
 
 case $(board_name) in
-zyxel,nwa50ax)
+zyxel,nwa50ax|\
+zyxel,nwa55axe)
 	uplink_port="lan"
 	;;
 ubnt,unifiac-lite|\


### PR DESCRIPTION
Otherwise the primary port stays empty and nothing works.