### PR TITLE
lock-password: dont't fail when already locked

### DIFF
--- a/package/uintent/files/lib/uintent/config.d/15-lock-password.sh
+++ b/package/uintent/files/lib/uintent/config.d/15-lock-password.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-passwd -l root
+passwd -l root || true


### PR DESCRIPTION
Fixes the following situation:

````
Configuring: 15-lock-password.sh
passwd: password for root is already locked
[...]
One or more upgrade scripts failed. Please review the above error messages.

````