### PR TITLE
lock-password: dont't fail when already locked

### DIFF
--- a/package/uintent/files/lib/uintent/config.d/15-lock-password.sh
+++ b/package/uintent/files/lib/uintent/config.d/15-lock-password.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
 
-passwd -l root
+PASSWD_OUT=$(passwd -l root 2>&1)
+PASSWD_ECO=$?
+
+if { [ "$PASSWD_ECO" -eq "1" ] && [ "$PASSWD_OUT" = "passwd: password for root is already locked" ]; } ||
+     [ "$PASSWD_ECO" -eq "0" ]; then
+	exit 0;
+fi
+
+echo "$PASSWD_OUT"
+exit "$PASSWD_ECO"


### PR DESCRIPTION
Fixes the following situation:

````
Configuring: 15-lock-password.sh
passwd: password for root is already locked
[...]
One or more upgrade scripts failed. Please review the above error messages.

````

To ensure that only locked accounts are ignored the stderr output is checked.

Alternative to #2 